### PR TITLE
Python3 Support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 bleach
-tornado
+tornado==4.5.3
 pycrypto


### PR DESCRIPTION
Awesome tool!! Unfortunately, the newest version of Tornado (5.0.2) throws the following error when using Python3 and will not start the web server. A work around is to use a lower version of Tornado (4.5.3) until this is fixed.

![trevorc2](https://user-images.githubusercontent.com/13889819/39376160-a9495538-4a1e-11e8-9a5d-e2264c3bd94c.png)

Hope this helps,
m8r0wn
