### PR TITLE
makefile, gitignore: structural change.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-agents/c/tc2_agent.*
+agents/c/tc2_client.*

--- a/agents/c/Makefile
+++ b/agents/c/Makefile
@@ -1,23 +1,34 @@
-CC:=gcc
+# GENERAL
+SOURCE := $(wildcard ./src/*)
+INCLUDE := ./include
+BINARY := tc2_client
+# POSIX
+CC := gcc
+POSIX_SOURCE := $(wildcard ./posix_src/*)
+# WINDOWS
+CC_WINDOWS := x86_64-w64-mingw32-gcc
+LDFLAGS_WINDOWS := ws2_32
 
 all: win posix
 
 debug: wind posixd
 
 win:
-	x86_64-w64-mingw32-gcc -Wall -I ./include/ -mwindows -DWIN_MAIN src/main.c src/crypto.c src/aes.c src/encode.c src/decode.c src/sha256.c posix_src/http.c -lws2_32 -o ./tc2_agent.exe
+	$(CC_WINDOWS) -Wall -I $(INCLUDE) -mwindows -DWIN_MAIN $(SOURCE) -l$(LDFLAGS_WINDOWS) -o ./$(BINARY).exe
 
 wind:
-	x86_64-w64-mingw32-gcc -g -Wall -DDEBUG -I ./include/ src/main.c src/crypto.c src/aes.c src/encode.c src/decode.c src/sha256.c posix_src/http.c -lws2_32 -o ./tc2_agent.exe
+	$(CC_WINDOWS) -g -Wall -DDEBUG -I $(INCLUDE) $(SOURCE) -l$(LDFLAGS_WINDOWS) -o ./$(BINARY).exe
 
 posix:
-	gcc -Wall -I ./include/ src/main.c src/crypto.c src/aes.c src/encode.c src/decode.c src/sha256.c posix_src/http.c -o ./tc2_agent.out
+	$(CC) -Wall -I $(INCLUDE) $(SOURCE) $(POSIX_SOURCE) -o ./$(BINARY).out
 
 posixd:
-	gcc -Wall -g -I ./include/ -DDEBUG src/main.c src/crypto.c src/aes.c src/encode.c src/decode.c src/sha256.c posix_src/http.c -o ./tc2_agent.out
+	$(CC) -Wall -g -I $(INCLUDE) -DDEBUG $(SOURCE) $(POSIX_SOURCE) -o ./$(BINARY).out
 
 scanbuild:
-	$(CC) -I ./include/ src/main.c src/crypto.c src/aes.c src/encode.c src/decode.c src/sha256.c posix_src/http.c -o ./tc2_agent.out
+	$(CC) -I $(INCLUDE) $(SOURCE) -o ./$(BINARY).out
 
 clean:
-	rm -f tc2_agent.*
+	rm -f $(BINARY).*
+
+.PHONY: all debug win wind posix posixd scanbuild clean

--- a/agents/c/Makefile
+++ b/agents/c/Makefile
@@ -8,25 +8,26 @@ POSIX_SOURCE := $(wildcard ./posix_src/*)
 # WINDOWS
 CC_WINDOWS := x86_64-w64-mingw32-gcc
 LDFLAGS_WINDOWS := ws2_32
+WINDOWS_SOURCE := $(POSIX_SOURCE)
 
 all: win posix
 
 debug: wind posixd
 
 win:
-	$(CC_WINDOWS) -Wall -I $(INCLUDE) -mwindows -DWIN_MAIN $(SOURCE) -l$(LDFLAGS_WINDOWS) -o ./$(BINARY).exe
+	$(CC_WINDOWS) -s -Wall -I $(INCLUDE) -mwindows -DWIN_MAIN $(SOURCE) $(WINDOWS_SOURCE) -l$(LDFLAGS_WINDOWS) -o ./$(BINARY).exe
 
 wind:
-	$(CC_WINDOWS) -g -Wall -DDEBUG -I $(INCLUDE) $(SOURCE) -l$(LDFLAGS_WINDOWS) -o ./$(BINARY).exe
+	$(CC_WINDOWS) -g -Wall -DDEBUG -I $(INCLUDE) $(SOURCE) $(WINDOWS_SOURCE) -l$(LDFLAGS_WINDOWS) -o ./$(BINARY).exe
 
 posix:
-	$(CC) -Wall -I $(INCLUDE) $(SOURCE) $(POSIX_SOURCE) -o ./$(BINARY).out
+	$(CC) -s -Wall -I $(INCLUDE) $(SOURCE) $(POSIX_SOURCE) -o ./$(BINARY).out
 
 posixd:
 	$(CC) -Wall -g -I $(INCLUDE) -DDEBUG $(SOURCE) $(POSIX_SOURCE) -o ./$(BINARY).out
 
 scanbuild:
-	$(CC) -I $(INCLUDE) $(SOURCE) -o ./$(BINARY).out
+	$(CC) -I $(INCLUDE) $(SOURCE) $(POSIX_SOURCE) -o ./$(BINARY).out
 
 clean:
 	rm -f $(BINARY).*


### PR DESCRIPTION
### Description

- The C agent was not compiling for POSIX and including the `./posix_src/*.c` solved the issue;
- Fixed naming mismatch between the binary name (client vs agent); and,
- Updated gitignore to address the changes.

### Commits

- **gitignore: agents: c:** match new name.
- **makefile: http.c**: fix missing include and...
  - Restructure of Makefile by leveraging variables.

_EDIT 4/6/2020 12:56pm UTC-3: Adding screenshot for context._
![image](https://user-images.githubusercontent.com/12863160/81199478-15fea680-8f99-11ea-867c-95407bee920c.png)
